### PR TITLE
fix(customSwitch): add the correct import

### DIFF
--- a/src/customSwitch.js
+++ b/src/customSwitch.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { View, StyleSheet, Text, TouchableWithoutFeedback, Animated, LayoutAnimation, Platform, UIManager } from 'react-native';
 
-import hexToRgb from './hexToRgb';
+import hexToRgb from './utils';
 
 if (Platform.OS === 'android') {
   if (UIManager.setLayoutAnimationEnabledExperimental) {


### PR DESCRIPTION
The import in customSwitch is pointing to a non-existing file. I have changed it to point to the correct "util" file.